### PR TITLE
Fix infinite loop bug

### DIFF
--- a/skiplist.go
+++ b/skiplist.go
@@ -188,8 +188,9 @@ func (t *SkipList) findExtended(key float64, findGreaterOrEqual bool) (foundElem
 				if findGreaterOrEqual {
 					foundElem = nextNode
 					ok = nextNode != nil
-					return
 				}
+
+				return
 			}
 		}
 	}

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -351,3 +351,16 @@ func TestString(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestInfiniteLoop(t *testing.T) {
+	list := New()
+	list.Insert(Element(1))
+
+	if _, ok := list.Find(Element(2)); ok {
+		t.Fail()
+	}
+
+	if _, ok := list.FindGreaterOrEqual(Element(2)); ok {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
### Problem

Using `Find` method on list can cause infinite loop. I think the reason is this d865d03eefc1f2e097e01466c22b2bb4f9fb543e commit, just misplaced `return` statement.

### Fix
`return` has been moved outside the condition, I also added test that fails due to timeout

Thank you.